### PR TITLE
Error in previous pull with comment out cisco library

### DIFF
--- a/cpal.py
+++ b/cpal.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from counter import counter
 import pandums
 from arista import device1 as arista
-#from cisco import cisco
+from cisco import cisco
 
 __author__ = "Jason Edelman and ...come help out!"
 __copyright__ = "Copyright 2014, The CPAL Project"


### PR DESCRIPTION
Jason, there was an error in the previous pull request.  Basically I made a change to my repository (that I wasn't expecting you to grab on the pull).  

I had temporarily commented out the 'from cisco import cisco' in cpal.py as I don't have the onepk libraries on my box. 

This will fix it.
