### PR TITLE
updated getHostname, added getCPU

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -18,7 +18,7 @@ import pandums
 import pprint
 import argparse
 from cpal.vendors.arista.apis.eapi.eapi import arista
-from cpal.vendors.cisco.apis.onepk.onepk import cisco
+#from cpal.vendors.cisco.apis.onepk.onepk import cisco
 from cpal.vendors.f5.apis.icontrol.icontrol import f5
 
 

--- a/core/main.py
+++ b/core/main.py
@@ -18,7 +18,7 @@ import pandums
 import pprint
 import argparse
 from cpal.vendors.arista.apis.eapi.eapi import arista
-#from cpal.vendors.cisco.apis.onepk.onepk import cisco
+from cpal.vendors.cisco.apis.onepk.onepk import cisco
 from cpal.vendors.f5.apis.icontrol.icontrol import f5
 
 

--- a/core/main.py
+++ b/core/main.py
@@ -60,7 +60,7 @@ class device():
             self.native = self._thisdevice.native
             #if self.native != 'DNE':
                 #print self.native
-            self.facts = self._thisdevice.getFacts()
+            self.facts = self.getFacts()
       	elif self.manufacturer.lower() == 'f5':
 			self._thisdevice = f5(self.address,self.obj)
 			self.native = self._thisdevice.native
@@ -68,6 +68,11 @@ class device():
 
         self.connected_devices = tracker.calc(self.obj,self.address,self.facts['hostname'])
 
+    # Yandy: added getFacts to device, to streamline the calling a bit.
+    # can easily be taken off, if not desired.
+    def getFacts(self):
+        self.facts = self._thisdevice.getFacts()
+        return self.facts
 
     def refreshFacts(self):
         self.facts = self._thisdevice.getFacts()
@@ -147,7 +152,14 @@ def createDevice(args):
     dev = device('dev',args['manufacturer'],args['ip_address'])
     #print dev.getserialNumber()
     function = args['function']
-    print getattr(dev,function)()
+    value = getattr(dev, function)()
+
+    # prettifies the printing a bit, in case the returned value is more complex than a string
+    if type(value) is dict:
+    	pp = pprint.PrettyPrinter(indent=4)
+    	pp.pprint(value)
+    else:
+    	print value
     
     if args['manufacturer'] == 'cisco':
         dev.native.disconnect()

--- a/vendors/arista/apis/eapi/eapi.py
+++ b/vendors/arista/apis/eapi/eapi.py
@@ -58,7 +58,7 @@ class arista():
         return up_time
 
     def getHostname(self):
-        output = self.getCmd( 1, ["show hostname"])
+        output = self.getCmd("show hostname")
         hostname = output[0]['hostname']
         return hostname
 

--- a/vendors/arista/apis/eapi/eapi.py
+++ b/vendors/arista/apis/eapi/eapi.py
@@ -58,7 +58,7 @@ class arista():
         return up_time
 
     def getHostname(self):
-        output = self.native.runCmds( 1, ["show hostname"],"json")
+        output = self.getCmd( 1, ["show hostname"])
         hostname = output[0]['hostname']
         return hostname
 

--- a/vendors/arista/apis/eapi/eapi.py
+++ b/vendors/arista/apis/eapi/eapi.py
@@ -57,6 +57,13 @@ class arista():
         up_time = c[13:].split(',')[0]
         return up_time
 
+    def getCPU(self):
+        output = self.native.runCmds(1, ['show processes top once'], 'text')
+        # cpu = index 0 of returned list  split by new-lines
+        # grabs the 3rd line which contains Cpu values at index [2]
+        cpu = output[0]['output'].split('\n')[2]
+        return cpu
+
     def getHostname(self):
         output = self.getCmd("show hostname")
         hostname = output[0]['hostname']

--- a/vendors/arista/apis/eapi/eapi.py
+++ b/vendors/arista/apis/eapi/eapi.py
@@ -79,9 +79,8 @@ class arista():
 
     def getFacts(self):
         #sh_ver = self.native.runCmds( 1, ["show version"] )
-        sh_uptime = self.native.runCmds( 1, ["show uptime"],"text" )
         #sh_lldp_localinfo = self.native.runCmds( 1, ["show lldp local-info"],"text")
-        #cpu_utilization = self.getCPU(ne)
+        cpu_utilization = self.getCPU()
         free_memory = self.getfreeMemory()
         total_memory = self.gettotalMemory()
         uptime = self.getUptime()
@@ -92,8 +91,9 @@ class arista():
 
         var_name = self.obj
 
-        facts = {'hostname': hostname, 'connect_ip': connect_ip,'platform':platform, 'serial_number':serial_number, 'system_uptime':uptime,'free_system_memory': free_memory,
-            'total_sytem_memory': total_memory,'vendor':'arista','var_name':var_name}
+        facts = {'hostname': hostname, 'connect_ip': connect_ip, 'platform':platform, 'serial_number':serial_number, \
+            'system_uptime':uptime, 'cpu_utilization':cpu_utilization, 'free_system_memory': free_memory,\
+            'total_sytem_memory': total_memory, 'vendor':'arista', 'var_name':var_name}
 
         config = ConfigObj('/home/cisco/apps/cpal/core/device_tags.ini').dict()
         for key in config.keys():

--- a/vendors/arista/apis/eapi/eapi.py
+++ b/vendors/arista/apis/eapi/eapi.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
-#arista.py
-#Jason Edelman
+
+#   ------------------------------------------------------------------
+#   Arista eAPI CPAL Integration
+#
+#   Written by: 
+#       Jason Edelman
+#   Updated by: 
+#       Yandy Ramirez, @IP_Yandy
+#   ------------------------------------------------------------------
 
 
 from jsonrpclib import Server
@@ -20,13 +27,10 @@ class arista():
     def jconnect(self):
 
         connect_string = "https://" + self.username + ":" + self.password + "@" + self.address + "/command-api"
-        #print connect_string
+
         switch = 'DNE'
         try:
-            #print 'Trying to connect...'
-            #print 'Using API: ', connect_string
             switch = Server(connect_string)
-            #print 'Connection made to ' + self.address + ' successfully.'
         except Exception, e:
             print e
             print 'Unable to connect to device.'
@@ -54,9 +58,9 @@ class arista():
         return up_time
 
     def getHostname(self):
-        output = self.native.runCmds( 1, ["show lldp local-info"],"text")
-        parse = output[0]['output'].split('\n')
-        return parse [3].strip()[16:-1]
+        output = self.native.runCmds( 1, ["show hostname"],"json")
+        hostname = output[0]['hostname']
+        return hostname
 
     def getfreeMemory(self):
         output = self.getCmd('show version')


### PR DESCRIPTION
updated getHostname() to use JSON instead of text, much easier to parse.

``` bash
$ python main.py -i 10.17.31.51 -m arista -n 'SW1' -f getHostname
eos-sw01
```

added getCPU method, returns entire line of cpu.

``` bash
$ python main.py -i 10.17.31.51 -m arista -n 'SW1' -f getCPU
Cpu(s): 11.2%us,  1.4%sy,  0.0%ni, 87.2%id,  0.2%wa,  0.0%hi,  0.0%si,  0.0%st
```

This can be changed to return only:

``` bash
Cpu(s): 11.2%us
```

or just

``` bash
11.2%us
```

First one is much more verbose, but let me know and I can commit the change before merging.

added getFacts to device(), to streamline the calling of getFacts a bit and allow to be called with the -f switch, added some pretty code to createDevice() to allow printing of complex data like dictionaries for testing.

``` bash
$ python main.py -i 10.17.31.51 -m arista -n 'SW1' -f getFacts
!
python main.py -i 10.17.31.51 -m arista -n 'SW1' -f getFacts
{   'connect_ip': '10.17.31.51',
    'cpu_utilization': u'Cpu(s): 11.0%us,  1.4%sy,  0.0%ni, 87.4%id,  0.1%wa,  0.0%hi,  0.0%si,  0.0%st',
    'free_system_memory': 1284928,
    'hostname': u'eos-sw01',
    'platform': u'DCS-7050T-64-R',
    'serial_number': u'JPE13020644',
    'system_uptime': u' 2:45',
    'total_sytem_memory': 3990500,
    'var_name': 'dev',
    'vendor': 'arista'}
```
