### PR TITLE
Streamlined eAPI + Other "Useful changes?"

### DIFF
--- a/core/main.py
+++ b/core/main.py
@@ -60,13 +60,13 @@ class device():
             self.native = self._thisdevice.native
             #if self.native != 'DNE':
                 #print self.native
-            self.facts = self.getFacts()
+            #self.facts = self.getFacts()
       	elif self.manufacturer.lower() == 'f5':
 			self._thisdevice = f5(self.address,self.obj)
 			self.native = self._thisdevice.native
 			self.facts = self._thisdevice.getFacts()
 
-        self.connected_devices = tracker.calc(self.obj,self.address,self.facts['hostname'])
+        #self.connected_devices = tracker.calc(self.obj,self.address,self.facts['hostname'])
 
     # Yandy: added getFacts to device, to streamline the calling a bit.
     # can easily be taken off, if not desired.

--- a/core/main.py
+++ b/core/main.py
@@ -18,7 +18,7 @@ import pandums
 import pprint
 import argparse
 from cpal.vendors.arista.apis.eapi.eapi import arista
-#from cpal.vendors.cisco.apis.onepk.onepk import cisco
+from cpal.vendors.cisco.apis.onepk.onepk import cisco
 from cpal.vendors.f5.apis.icontrol.icontrol import f5
 
 

--- a/core/main.py
+++ b/core/main.py
@@ -18,7 +18,7 @@ import pandums
 import pprint
 import argparse
 from cpal.vendors.arista.apis.eapi.eapi import arista
-from cpal.vendors.cisco.apis.onepk.onepk import cisco
+#from cpal.vendors.cisco.apis.onepk.onepk import cisco
 from cpal.vendors.f5.apis.icontrol.icontrol import f5
 
 
@@ -60,13 +60,13 @@ class device():
             self.native = self._thisdevice.native
             #if self.native != 'DNE':
                 #print self.native
-            #self.facts = self.getFacts()
+            self.facts = self.getFacts()
       	elif self.manufacturer.lower() == 'f5':
 			self._thisdevice = f5(self.address,self.obj)
 			self.native = self._thisdevice.native
 			self.facts = self._thisdevice.getFacts()
 
-        #self.connected_devices = tracker.calc(self.obj,self.address,self.facts['hostname'])
+        self.connected_devices = tracker.calc(self.obj,self.address,self.facts['hostname'])
 
     # Yandy: added getFacts to device, to streamline the calling a bit.
     # can easily be taken off, if not desired.

--- a/vendors/arista/apis/eapi/eapi.py
+++ b/vendors/arista/apis/eapi/eapi.py
@@ -22,7 +22,16 @@ class arista():
         self.address = address
         self.obj = obj
         self.native = self.jconnect()
-        self.facts = self.getFacts()
+
+        # self.version = self.getVersionInfo() must be place here
+        # after call to jconnect()
+        self.version_info = self.getVersionInfo()
+
+        # self.facts = self.getFacts()
+        # self.facts values populated once getFacts() is called
+        # callign getFacts() while initializing the object, makes it inefficient 
+        # if a user wants to see the "facts" they should call getFacts() not object.facts 
+        self.facts = {}
 
     def jconnect(self):
 
@@ -41,15 +50,15 @@ class arista():
         return self.native.runCmds( 1, [cmd] )
 
     def getPlatform(self):
-        output = self.getCmd('show version')
-        return output[0]["modelName"]
+        #output = self.getCmd('show version')
+        return self.version_info[0]["modelName"]
 
     def getserialNumber(self):
-        output = self.getCmd('show version')
-        if output[0]["serialNumber"] == '':
+        #output = self.getCmd('show version')
+        if self.version_info[0]["serialNumber"] == '':
             return '12345'
         else:
-            return output[0]["serialNumber"]
+            return self.version_info[0]["serialNumber"]
 
     def getUptime(self):
         output = self.native.runCmds( 1, ["show uptime"],"text")
@@ -61,24 +70,101 @@ class arista():
         output = self.native.runCmds(1, ['show processes top once'], 'text')
         # cpu = index 0 of returned list  split by new-lines
         # grabs the 3rd line which contains Cpu values at index [2]
-        cpu = output[0]['output'].split('\n')[2]
+        cpu_line = output[0]['output'].split('\n')[2]
+
+        # cpu is then narrowed down to the actual usage, up to the first instance of a comma ','
+        cpu = cpu_line[0:cpu_line.find(',')]
         return cpu
 
     def getHostname(self):
-        output = self.getCmd("show hostname")
-        hostname = output[0]['hostname']
+        ''' Returns the device's none FQDN hostname '''
+
+        version_int = self._versionList()
+
+        if int(version_int[0]) >= 4 and int(version_int[1]) >= 13:
+            output = self.getCmd("show hostname")
+            hostname = output[0]['hostname']
+        else:
+            # begins a breakdown of finding the hostname inside a string
+            # could probably be more efficient, but works for now
+            output = self.native.runCmds(1, ['show lldp local-info'], 'text')
+
+            # gets the 4th line of output which contains the hostname in FQDN format
+            host_line = output[0]['output'].split('\n')[3]
+
+            # splits the line into a list at the delimeter and assigns the 2nd indext to fqdn
+            # 2nd index contains the hostname
+            host_fqdn = host_line.split(':')[1]
+
+            # assignes the first index of fqdn after splitting at the delimeter (.)
+            # this splits the fqdn into three parts, the [hostname, domain, suffix]
+            hostname = host_fqdn.split('.')[0]
+
+            # indexing removes the " from the begining of the hostname
+            return hostname[2:]
+
+
+        return hostname
+
+    def getFQDN(self):
+        ''' 
+            Returns the device's FQDN hostname.domain.suffix
+            has not been added to main.py yet, waiting to make sure 
+            their's support accross platforms
+        '''
+
+        version_int = self._versionList()
+
+        if int(version_int[0]) >= 4 and int(version_int[1]) >= 13:
+            output = self.getCmd("show hostname")
+            hostname = output[0]['fqdn']
+
+        else:
+            # begins a breakdown of finding the hostname inside a string
+            # could probably be more efficient, but works for now
+            output = self.native.runCmds(1, ['show lldp local-info'], 'text')
+
+            # gets the 4th line of output which contains the hostname in FQDN format
+            host_line = output[0]['output'].split('\n')[3]
+
+            # splits the line into a list at the delimeter and assigns the 2nd indext to fqdn
+            # 2nd index contains the hostname
+            hostname = host_line.split(':')[1]
+
+            # indexing removes the quotes (") from the begining and end of the hostname
+            return hostname[2:-1]
+
+
         return hostname
 
     def getfreeMemory(self):
-        output = self.getCmd('show version')
-        return output[0]['memFree']
+        #output = self.getCmd('show version')
+        return self.version_info[0]['memFree']
 
     def gettotalMemory(self):
-        output = self.getCmd('show version')
-        return output[0]['memTotal']
+        #output = self.getCmd('show version')
+        return self.version_info[0]['memTotal']
+
+    # getVersionInfo created to streamline the calling of "show version"
+    # there was allot of code that repeated it, this way, only one call is needed
+    # speeds up the process and makes it more efficient.
+    def getVersionInfo(self):
+        ''' returns a 'show version' output as a dictionary '''
+        
+        version_info = self.getCmd('show version')
+        return version_info
+
+    def _versionList(self):
+        ''' 
+            Gets version and converts to a list of Ivalues
+            this allows comparisons between software versions
+            by calling int(on an index)
+        '''
+        version_list = self.version_info[0]['version'].split('.')
+        return version_list
 
     def getFacts(self):
-        #sh_ver = self.native.runCmds( 1, ["show version"] )
+        sh_ver = self.version_info[0]['version']
         #sh_lldp_localinfo = self.native.runCmds( 1, ["show lldp local-info"],"text")
         cpu_utilization = self.getCPU()
         free_memory = self.getfreeMemory()
@@ -91,14 +177,14 @@ class arista():
 
         var_name = self.obj
 
-        facts = {'hostname': hostname, 'connect_ip': connect_ip, 'platform':platform, 'serial_number':serial_number, \
-            'system_uptime':uptime, 'cpu_utilization':cpu_utilization, 'free_system_memory': free_memory,\
-            'total_sytem_memory': total_memory, 'vendor':'arista', 'var_name':var_name}
+        self.facts = {'hostname': hostname, 'connect_ip': connect_ip, 'platform':platform, 'version':sh_ver,\
+            'serial_number':serial_number, 'system_uptime':uptime, 'cpu_utilization':cpu_utilization, \
+            'free_system_memory': free_memory, 'total_sytem_memory': total_memory, 'vendor':'arista', 'var_name':var_name}
 
         config = ConfigObj('/home/cisco/apps/cpal/core/device_tags.ini').dict()
         for key in config.keys():
             if key == self.address:
-                facts.update(config[key])
+                self.facts.update(config[key])
 
-        return facts
+        return self.facts
 

--- a/vendors/arista/apis/eapi/eapi.py
+++ b/vendors/arista/apis/eapi/eapi.py
@@ -24,14 +24,10 @@ class arista():
         self.native = self.jconnect()
 
         # self.version = self.getVersionInfo() must be place here
-        # after call to jconnect()
+        # after call to jconnect() and before getFacts()
         self.version_info = self.getVersionInfo()
 
-        # self.facts = self.getFacts()
-        # self.facts values populated once getFacts() is called
-        # callign getFacts() while initializing the object, makes it inefficient 
-        # if a user wants to see the "facts" they should call getFacts() not object.facts 
-        self.facts = {}
+        self.facts = self.getFactsNew()
 
     def jconnect(self):
 
@@ -163,7 +159,7 @@ class arista():
         version_list = self.version_info[0]['version'].split('.')
         return version_list
 
-    def getFacts(self):
+    def getFactsNew(self):
         sh_ver = self.version_info[0]['version']
         #sh_lldp_localinfo = self.native.runCmds( 1, ["show lldp local-info"],"text")
         cpu_utilization = self.getCPU()
@@ -188,3 +184,5 @@ class arista():
 
         return self.facts
 
+    def getFacts(self):
+        return self.facts

--- a/vendors/arista/apis/eapi/eapi.py
+++ b/vendors/arista/apis/eapi/eapi.py
@@ -27,7 +27,7 @@ class arista():
         # after call to jconnect() and before getFacts()
         self.version_info = self.getVersionInfo()
 
-        self.facts = self.getFactsNew()
+        self.facts = self.refreshFacts()
 
     def jconnect(self):
 
@@ -159,7 +159,7 @@ class arista():
         version_list = self.version_info[0]['version'].split('.')
         return version_list
 
-    def getFactsNew(self):
+    def refreshFacts(self):
         sh_ver = self.version_info[0]['version']
         #sh_lldp_localinfo = self.native.runCmds( 1, ["show lldp local-info"],"text")
         cpu_utilization = self.getCPU()


### PR DESCRIPTION
Added getVersionInfo(), there was allot of code that constantly kept calling "show version" creating a new connection and waiting. Now there's one call, and all the other methods use the version_info variable to read this info (only one call made), should be more efficient.

Added _versionList() which returns a list of the version string, unconverted. This allows to convert the members of the list to int and check for version #, for command compatibility, first instance of this is in getHostname().

Changed getHostname() to test the version and run the correct command depending on the version found.

Added getFQDN() to return the fully qualified domain name of the device, but has not been added to main.py yet, in case it's not compatible across platforms.

---

p.s

We may want to re-think how getFacts() works, every call to it, refreshes all the values and there are at least two calls by just initializing the object. i.e:

with arista, the **init** method has a call to getFacts(), then deviceCalls() has a line to getFacts(), then every other subsequent one after that. 

I modified the eapi.py to show, **init** now calls refreshFacts(), since this call was already made, now deviceCalls line to getFacts() is just using the data already available. If the information needs to be refreshed, then a call to refreshFacts in device will call refreshFacts in the platform specific version.

I did not change main.py to reflect this, only the arista part just want to make sure we're in the same page and discuss it a bit more.

---

``` bash
$ python main.py -i 10.17.31.51 -m arista -n 'SW1' -f getFacts
{   'connect_ip': '10.17.31.51',
    'cpu_utilization': u'Cpu(s):  9.9%us',
    'free_system_memory': 1290508,
    'hostname': u'eos-sw01',
    'platform': u'DCS-7050T-64-R',
    'serial_number': u'JPE13020644',
    'system_uptime': u'15:04',
    'total_sytem_memory': 3990500,
    'var_name': 'dev',
    'vendor': 'arista',
    'version': u'4.13.2F'}
```

``` bash
$ python main.py -i 192.168.31.21 -m arista -n 'SW1' -f getFacts
{   'connect_ip': '192.168.31.21',
    'cpu_utilization': u'Cpu(s):  7.0%us',
    'free_system_memory': 57348,
    'hostname': u'vEOS-1',
    'platform': u'vEOS',
    'serial_number': '12345',
    'system_uptime': u'1 day',
    'total_sytem_memory': 1000444,
    'var_name': 'dev',
    'vendor': 'arista',
    'version': u'4.12.1-1581426.vEOS4125.1 (engineering build)'}
```

getHostname() with different device versions as shown above

``` bash
$ python main.py -i 10.17.31.51 -m arista -n 'SW1' -f getHostname
eos-sw01
```

``` bash
$ python main.py -i 192.168.31.21 -m arista -n 'SW1' -f getHostname
vEOS-1
```
