### PR TITLE
Added checks for version_info and Updated getFacts

### DIFF
--- a/vendors/arista/apis/eapi/eapi.py
+++ b/vendors/arista/apis/eapi/eapi.py
@@ -180,6 +180,10 @@ class arista():
     def getVersion(self):
         ''' Returns the device running code version as a string '''
 
+        # checks if self.version_info is not empy
+        if not self.version_info:
+            self.getVersionInfo()
+            
         return self.version_info[0]['version']
 
     def getFacts(self):


### PR DESCRIPTION
added checking to make sure self.version_info exists in the methods that use it, otherwise it gets instantiated. Moved the initial call of version_info to getFacts() to reduce a bit of redundancy and make its somewhat more efficient. Since getFacts() is called when device() is instantiated.
